### PR TITLE
fileDir, if you want to place file at specific directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'Name of the file when written to temp location'
     required: true
     default: 'decoded-file.file'
+  fileDir:
+    description: 'If it is set, change the output location to specific one from temp location.'
+    required: false
   encodedString:
     description: 'The base64 encoded string'
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -469,9 +469,6 @@ if (core.getInput('fileDir', {required: false})) {
   fileName = path.join(process.env.RUNNER_TEMP,core.getInput('fileName'));
 }
 
-console.log(core.getInput('fileDir', {required: false}));
-console.log(fileName);
-
 var encodedString = core.getInput('encodedString');
 
 // most @actions toolkit packages have async methods

--- a/dist/index.js
+++ b/dist/index.js
@@ -462,26 +462,34 @@ const fse = __webpack_require__(226)
 const path = __webpack_require__(622);
 
 // get input parameter values from config
-var fileName = path.join(process.env.RUNNER_TEMP,core.getInput('fileName'));
+var fileName;
+if (core.getInput('fileDir', {required: false})) {
+  fileName = path.join(core.getInput('fileDir'), core.getInput('fileName', {required: false}));
+} else {
+  fileName = path.join(process.env.RUNNER_TEMP,core.getInput('fileName'));
+}
+
+console.log(core.getInput('fileDir', {required: false}));
+console.log(fileName);
 
 var encodedString = core.getInput('encodedString');
 
 // most @actions toolkit packages have async methods
 async function run() {
-  try { 
+  try {
     console.log(process.env);
     const tempFile = Buffer.from(encodedString, 'base64');
-    
+
     if (tempFile.length == 0)
       core.setFailed('Temporary file value is not set');
-    
+
     fse.outputFile(fileName, tempFile, (err) => {
       if (err) throw err;
       console.log('Wrote file!');
     });
 
     core.setOutput('filePath', fileName);
-  } 
+  }
   catch (error) {
     core.setFailed(error.message);
   }

--- a/index.js
+++ b/index.js
@@ -10,9 +10,6 @@ if (core.getInput('fileDir', {required: false})) {
   fileName = path.join(process.env.RUNNER_TEMP,core.getInput('fileName'));
 }
 
-console.log(core.getInput('fileDir', {required: false}));
-console.log(fileName);
-
 var encodedString = core.getInput('encodedString');
 
 // most @actions toolkit packages have async methods

--- a/index.js
+++ b/index.js
@@ -3,26 +3,34 @@ const fse = require('fs-extra')
 const path = require('path');
 
 // get input parameter values from config
-var fileName = path.join(process.env.RUNNER_TEMP,core.getInput('fileName'));
+var fileName;
+if (core.getInput('fileDir', {required: false})) {
+  fileName = path.join(core.getInput('fileDir'), core.getInput('fileName', {required: false}));
+} else {
+  fileName = path.join(process.env.RUNNER_TEMP,core.getInput('fileName'));
+}
+
+console.log(core.getInput('fileDir', {required: false}));
+console.log(fileName);
 
 var encodedString = core.getInput('encodedString');
 
 // most @actions toolkit packages have async methods
 async function run() {
-  try { 
+  try {
     console.log(process.env);
     const tempFile = Buffer.from(encodedString, 'base64');
-    
+
     if (tempFile.length == 0)
       core.setFailed('Temporary file value is not set');
-    
+
     fse.outputFile(fileName, tempFile, (err) => {
       if (err) throw err;
       console.log('Wrote file!');
     });
 
     core.setOutput('filePath', fileName);
-  } 
+  }
   catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
For files such as [`sentry.properties`](https://docs.sentry.io/platforms/java/configuration/) that need to be placed in ROOT_DIR at build time, you need to move the file from the temp directory.
By setting `fileDir`, the output destination can be changed from a temporary location to a specific location.

There was also a related Issue.

https://github.com/timheuer/base64-to-file/issues/15