### PR TITLE
fix: update branch trigger to match with default branch change

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -3,13 +3,13 @@ name: "Action Test"
 on:
    push:
      branches:
-       - master
+       - main
    workflow_dispatch:
      branches:
-       - master
+       - main
 
 jobs:
-  # test action works running from the graph  
+  # test action works running from the graph
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -31,7 +31,7 @@ jobs:
       uses: ./
       with:
         fileName: 'myTemporaryFile.json'
-        encodedString: ${{ secrets.ENCODED_JSON }} 
+        encodedString: ${{ secrets.ENCODED_JSON }}
 
     - name: Echo file
       run: |


### PR DESCRIPTION
👋 looks like the default branch got changed at some point before, but the branch trigger is still using `master` branch, so fixing the workflow setup. 

cc @timheuer 